### PR TITLE
Add IRONIC_README.md with project overview and insights

### DIFF
--- a/IRONIC_README.md
+++ b/IRONIC_README.md
@@ -1,0 +1,32 @@
+🧪 Started a pet project: a URL shortener, but make it microservices and anxiety. Everything hurts, and that’s the architecture.
+
+🎬 Title: “FastAPI & Kafka: Into the Abyss”
+
+🧩 Tech Stack:
+
+FastAPI — because Flask is for the sane, and I chose suffering.
+
+PostgreSQL + Redis — the classic duo: one forgets nothing, the other forgets everything too quickly.
+
+Kafka — so my services can scream into the void and hope someone’s listening.
+
+MongoDB — the emotional journal for suspicious URLs.
+
+Google Safe Browsing — our spiritual guide and URL bouncer.
+
+🐙 Architecture in a nutshell: — User submits a URL.
+— I don’t trust it. Kafka doesn’t either.
+— The URL gets validated by a microservice that reads too much Google documentation.
+— Redis pretends it remembers things.
+— MongoDB records the moral failings of the link.
+
+⚙️ Project status: — It technically works... but only in my local hell.
+— Frontend is still being imagined.
+— CI/CD is currently “CI… someday”.
+
+🧘‍♂️ What I’ve learned: — Microservices are like teenagers: independent but constantly yelling at each other through Kafka.
+— Redis lies to your face, but it lies fast.
+— “URL shortener” sounds simple until you build it like a low-budget Netflix backend.
+
+📦 Repo here: [[link](https://github.com/VladimirKomov/url-shortener)]
+(Warning: may shorten your confidence.)


### PR DESCRIPTION
Introduced a detailed and humor-laden README file for the URL shortener project. It outlines the tech stack, architecture, current status, and lessons learned, combining technical accuracy with a playful narrative style.