### PR TITLE
Refactor networks and improve service handling in Docker setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,28 @@ rebuild:
 	$(COMPOSE) build
 	$(COMPOSE) up
 
+# recreating Zookeeper changes cluster.id ,
+# you need to clear the Kafka volume, or write it manually, but that's lazy
+rebuild-kafka:
+	docker-compose \
+		-f docker/docker-compose.base.yml \
+		-f docker/docker-compose.kafka.yml \
+		down -v --remove-orphans
+	docker-compose \
+		-f docker/docker-compose.base.yml \
+		-f docker/docker-compose.kafka.yml \
+		up -d --build
+
+restart-services:
+	docker-compose \
+		-f docker/docker-compose.base.yml \
+		-f docker/docker-compose.postgres.yml \
+		-f docker/docker-compose.redis.yml \
+		-f docker/docker-compose.mongoDB.yml \
+		-f docker/docker-compose.kafka.yml \
+		-f docker/docker-compose.services.yml \
+		up -d --build
+
 validate:
 	$(COMPOSE) config
 

--- a/backend/shortener_service/app/core/config.py
+++ b/backend/shortener_service/app/core/config.py
@@ -17,7 +17,5 @@ class Config:
     KAFKA_TOPIC_URL_VALIDATION: str = os.getenv("KAFKA_TOPIC_URL_VALIDATION")
     KAFKA_GROUP_ID: str = os.getenv("KAFKA_GROUP_ID")
     KAFKA_TOPIC_VALIDATION_RESULT: str = os.getenv("KAFKA_TOPIC_VALIDATION_RESULT")
-    KAFKA_USERNAME: str = os.getenv("KAFKA_USERNAME")
-    KAFKA_PASSWORD: str = os.getenv("KAFKA_PASSWORD")
 
 config = Config()

--- a/backend/shortener_service/app/databases/redis.py
+++ b/backend/shortener_service/app/databases/redis.py
@@ -13,7 +13,7 @@ class RedisClient(BaseAsyncClient):
         try:
             result = await self.client.ping()
             logger.debug(f"Ping result: {result}")
-            return str(result).upper() == "PONG"
+            return result is True
         except Exception as e:
             logger.warning(f"Ping failed with error: {e}")
             return False

--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -8,5 +8,5 @@ volumes:
   kafka_data:
 
 networks:
-  kafka_network:
+  url_shortener_network:
     driver: bridge

--- a/docker/docker-compose.kafka.yml
+++ b/docker/docker-compose.kafka.yml
@@ -11,7 +11,7 @@ services:
       # memory limit
       KAFKA_HEAP_OPTS: "-Xmx256M -Xms128M"
     networks:
-      - kafka_network
+      - url_shortener_network
 
   kafka:
     image: confluentinc/cp-kafka:latest
@@ -34,7 +34,7 @@ services:
     depends_on:
       - zookeeper
     networks:
-      - kafka_network
+      - url_shortener_network
     volumes:
       - kafka_data:/var/lib/kafka/data
 
@@ -50,5 +50,5 @@ services:
     depends_on:
       - kafka
     networks:
-      - kafka_network
+      - url_shortener_network
 

--- a/docker/docker-compose.mongoDB.yml
+++ b/docker/docker-compose.mongoDB.yml
@@ -14,4 +14,4 @@ services:
     volumes:
       - mongo_data:/data/db
     networks:
-      - kafka_network
+      - url_shortener_network

--- a/docker/docker-compose.postgres.yml
+++ b/docker/docker-compose.postgres.yml
@@ -15,4 +15,4 @@ services:
     volumes:
       - pg_data:/var/lib/postgresql/data
     networks:
-      - kafka_network
+      - url_shortener_network

--- a/docker/docker-compose.redis.yml
+++ b/docker/docker-compose.redis.yml
@@ -27,4 +27,4 @@ services:
     volumes:
       - redis_data:/data
     networks:
-      - kafka_network
+      - url_shortener_network

--- a/docker/docker-compose.services.yml
+++ b/docker/docker-compose.services.yml
@@ -17,7 +17,7 @@ services:
       - redis
       - postgres
     networks:
-      - kafka_network
+      - url_shortener_network
 
   url_validator:
     build:
@@ -31,4 +31,4 @@ services:
       - kafka
       - mongo
     networks:
-      - kafka_network
+      - url_shortener_network

--- a/docker/docker-compose_full_old.yml
+++ b/docker/docker-compose_full_old.yml
@@ -60,7 +60,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       KAFKA_HEAP_OPTS: "-Xmx256M -Xms128M"
     networks:
-      - kafka_network
+      - url_shortener_network
 
   # Kafka
   kafka:
@@ -81,7 +81,7 @@ services:
     depends_on:
       - zookeeper
     networks:
-      - kafka_network
+      - url_shortener_network
     volumes:
       - kafka_data:/var/lib/kafka/data
 
@@ -98,7 +98,7 @@ services:
     depends_on:
       - kafka
     networks:
-      - kafka_network
+      - url_shortener_network
 
   # FastAPI URL Shortener Service
   shortener_service:
@@ -116,7 +116,7 @@ services:
       - redis
       - postgres
     networks:
-      - kafka_network
+      - url_shortener_network
 
   # URL Validator (Kafka Consumer)
   url_validator:
@@ -131,10 +131,10 @@ services:
       - kafka
       - mongo
     networks:
-      - kafka_network
+      - url_shortener_network
 
 networks:
-  kafka_network:
+  url_shortener_network:
     driver: bridge
 
 volumes:


### PR DESCRIPTION
Renamed "kafka_network" to "url_shortener_network" for clarity and alignment across all services. Added new targets `rebuild-kafka` and `restart-services` to the Makefile for more efficient service management. Simplified Redis ping logic and removed unused Kafka credentials from configuration.