### PR TITLE
Add MongoDB integration for click event tracking

### DIFF
--- a/backend/statistics-service/src/app.module.ts
+++ b/backend/statistics-service/src/app.module.ts
@@ -4,16 +4,19 @@ import {UrlClickConsumer} from "./consumers/url-click.consumer";
 import {ClickStatsService} from './services/click-stats/click-stats.service';
 import {MongooseModule} from "@nestjs/mongoose";
 import {MongoConfigService} from "./database/mongo-config.service";
+import {ClickEventEntity, ClickEventSchema} from "./models/click-event.schema";
 
 @Module({
     imports: [
         ConfigModule.forRoot({
             isGlobal: true,
         }),
-
         MongooseModule.forRootAsync({
             useClass: MongoConfigService,
         }),
+        MongooseModule.forFeature([
+            {name: ClickEventEntity.name, schema: ClickEventSchema},
+        ]),
     ],
     controllers: [
         UrlClickConsumer,

--- a/backend/statistics-service/src/consumers/url-click.consumer.ts
+++ b/backend/statistics-service/src/consumers/url-click.consumer.ts
@@ -3,17 +3,21 @@ import {EventPattern, Payload} from "@nestjs/microservices";
 import {RawClickEventDto} from "../dto/click-event.dto";
 import {mapRawClickEvent} from "../mappers/click-event.mapper";
 import {createLogger} from "../utils/logger.util";
+import {ClickStatsService} from "../services/click-stats/click-stats.service";
 
 @Controller()
 export class UrlClickConsumer {
     private readonly logger = createLogger(UrlClickConsumer.name);
 
-    @EventPattern(process.env.RABBITMQ_QUEUE_CLICK_EVENTS || 'click_events')
+    constructor(private readonly statsService: ClickStatsService) {}
+
+    @EventPattern('click_events')
     async handleClickEvent(@Payload() rawData: RawClickEventDto) {
         const data = mapRawClickEvent(rawData);
         this.logger.log('Get massage from RabbitMQ:', data.shortCode);
         this.logger.debug(
             'Get massage from RabbitMQ:',
             JSON.stringify(data, null, 2))
+        await this.statsService.handleClickEvent(data);
     }
 }

--- a/backend/statistics-service/src/dto/click-event.dto.ts
+++ b/backend/statistics-service/src/dto/click-event.dto.ts
@@ -13,3 +13,11 @@ export interface ClickEventDto {
     referer?: string;
     timestamp: Date;
 }
+
+export interface ClickEventResponseDto {
+    shortCode: string;
+    ipAddress: string;
+    userAgent?: string;
+    referer?: string;
+    timestamp: Date;
+}

--- a/backend/statistics-service/src/mappers/click-event.mapper.ts
+++ b/backend/statistics-service/src/mappers/click-event.mapper.ts
@@ -1,4 +1,4 @@
-import {ClickEventDto, RawClickEventDto} from "../dto/click-event.dto";
+import {ClickEventDto, ClickEventResponseDto, RawClickEventDto} from "../dto/click-event.dto";
 
 export const mapRawClickEvent = (rawClickEvent: RawClickEventDto): ClickEventDto => {
     return {
@@ -9,4 +9,14 @@ export const mapRawClickEvent = (rawClickEvent: RawClickEventDto): ClickEventDto
         timestamp: new Date(rawClickEvent.timestamp)
     }
 };
+
+export const mapClickEventToResponse = (doc: any): ClickEventResponseDto => {
+    return {
+        shortCode: doc.shortCode,
+        ipAddress: doc.ipAddress,
+        userAgent: doc.userAgent,
+        referer: doc.referer,
+        timestamp: doc.timestamp.toISOString()
+    }
+}
 

--- a/backend/statistics-service/src/services/click-stats/click-stats.service.ts
+++ b/backend/statistics-service/src/services/click-stats/click-stats.service.ts
@@ -1,18 +1,39 @@
 import { Injectable } from '@nestjs/common';
-import {ClickEventDto} from "../../dto/click-event.dto";
+import {ClickEventDto, ClickEventResponseDto} from "../../dto/click-event.dto";
 import {createLogger} from "../../utils/logger.util";
+import {InjectModel} from "@nestjs/mongoose";
+import {ClickEventDocument, ClickEventEntity} from "../../models/click-event.schema";
+import {Model} from "mongoose";
+import {mapClickEventToResponse} from "../../mappers/click-event.mapper";
 
 @Injectable()
 export class ClickStatsService {
     private readonly logger = createLogger(ClickStatsService.name);
 
-    async handleClickEvent(event: ClickEventDto) {
+    constructor(
+        @InjectModel(ClickEventEntity.name)
+        private readonly clickEventModel: Model<ClickEventDocument>,
+    ) {}
 
+    async handleClickEvent(event: ClickEventDto) {
+        this.logger.log(`Saving click for shortCode=${event.shortCode}`);
+
+        await this.clickEventModel.create({
+            shortCode: event.shortCode,
+            ipAddress: event.ipAddress,
+            userAgent: event.userAgent,
+            referer: event.referer,
+            timestamp: event.timestamp || new Date(),
+        });
     }
 
-    async getClickStats() {
-        return {
-            clicks: 1
-        }
+    async getClickStats(shortCode: string): Promise<ClickEventResponseDto[]> {
+
+        const raw = await  this.clickEventModel
+            .find({ shortCode })
+            .sort({ timestamp: -1 })
+            .lean();
+
+        return raw.map(mapClickEventToResponse)
     }
 }


### PR DESCRIPTION
Introduced `ClickEventEntity` schema and database connectivity for storing click events using Mongoose. Updated `ClickStatsService` to save and retrieve click events, mapped responses, and integrated the service into `UrlClickConsumer` for event processing.